### PR TITLE
Create 以梦为马UI效果V2.0

### DIFF
--- a/UI/以梦为马UI效果V2.0
+++ b/UI/以梦为马UI效果V2.0
@@ -1,0 +1,1 @@
+![a](http://att2.citysbs.com/hangzhou/2016/06/17/13/middle_589x634-130230_v2_11621466139750964_c4f790f4a2f347c4b4cdae4f7e0980f0.jpg)


### PR DESCRIPTION
漆面测试No.1 宝马7系
　　厂商指导售价区间：89.80-265.80万元
　　车型特点：宝马旗舰轿车，支持个性订制，漆面平均厚度347.1μm。